### PR TITLE
No longer require the bizarre symlink of the theme when developing locally.

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,22 +21,26 @@ There are two commands, and they use the same arguments which are explained belo
 * `--config-dir <path>`
   * Where `<path>` is a local checkout of the configuration.
   * Either this option, or the previous option is required.
-* `--theme-dir <path>`
-  * While it would be great if this worked when pointed anywhere on the system, a Hexo limitation prevents it from reaching outside the root of this repository, so you'll need to symlink your local Git checkout into `themes/meteor` and then run this as `--theme-dir themes/meteor`.
+* `--theme-dir <path>` (defaults to `meteor-theme-hexo` installed from npm)
 
 ## Examples
 
-**For the configuration, use your local checkout which is alongside this theme in `../apollo-hexo-config` along with a local copy of the theme which you've symlinked into `themes/meteor`.**
+**For the configuration, use your local checkout which is alongside this theme in `../apollo-hexo-config` along with a local copy of the theme which is alongside in `../meteor-theme-hexo`.
 ```
-npm run server --  --config-dir ../apollo-hexo-config --theme-dir themes/meteor
-```
-
-**Use the locally symlinked version of the theme you've put in `themes/meteor`.**
-```
-npm run server --  --config-pkg apollo-hexo-config --theme-dir themes/meteor
+npm run server --  --config-dir ../apollo-hexo-config --theme-dir ../meteor-theme-hexo
 ```
 
-**Use the Meteor Hexo configuration**
+**Use the Apollo config from npm, but the local checkout of the theme.
+```
+npm run server --  --config-pkg apollo-hexo-config --theme-dir ../meteor-theme-hexo
+```
+
+**Use the (published) Apollo config and the theme, both via npm install.
+```
+npm run server -- --config-pkg apollo-hexo-config
+```
+
+**Use the (published) Meteor config and the theme, both via npm install.
 ```
 npm run server --  --config-pkg meteor-hexo-config
 ```

--- a/tools/theme_instance.js
+++ b/tools/theme_instance.js
@@ -15,7 +15,6 @@ const { existsSync } = require("fs");
 const assert = require("assert");
 const {
   themeName,
-  writeThemeOverrideConfig,
 } = require("./utils.js");
 
 class ThemeInstance {
@@ -60,6 +59,15 @@ class ThemeInstance {
         "An error occurred installing npm packages for the 'theme-example'.");
     }
 
+    function linkNpmPackages (...dirs) {
+      const toInstall = dirs.join(" ");
+      const code = shelljs.exec(
+        `npm install --link ${skipPackageJsons} ${toInstall}`).code;
+
+      assert.strictEqual(code, 0,
+        "An error occurred installing npm packages for the 'theme-example'.");
+    }
+
     const {
       configPackage,
       configDirectory,
@@ -79,6 +87,7 @@ class ThemeInstance {
       installNpmPackages(themeName);
       configPath = require(pathResolve(this._parentDir, configDirectory));
     } else if (configDirectory) {
+      linkNpmPackages(themeDirectory);
       configPath = require(pathResolve(this._parentDir, configDirectory));
     }
 
@@ -90,22 +99,6 @@ class ThemeInstance {
     assert.ok(
       existsSync(pathResolve(".", configPath)),
       "The _config.yml couldn't be found at: " + configPath);
-
-    if (themeDirectory) {
-      const relativeThemeDirectory =
-        pathRelative(this._parentDir, themeDirectory);
-
-      assert.strictEqual(relativeThemeDirectory.startsWith(".."), false,
-        "Currently, Hexo cannot reach outside its root to find the theme.  " +
-        "Instead, please create a symlink from your local theme checkout to " +
-        "`themes/meteor` and invoke this script with " +
-        "`--theme-dir themes/meteor`.  A future version of this script, " +
-        "possibly thanks to work from _you_ (*nudge, nudge*), might create " +
-        "this symlink for you!");
-
-      this.configPathTheme =
-        await writeThemeOverrideConfig(relativeThemeDirectory);
-    }
 
     this.configPath = configPath;
   }

--- a/tools/utils.js
+++ b/tools/utils.js
@@ -55,23 +55,9 @@ function getConfigFromArguments(cmd = "generate") {
   return options;
 }
 
-
-async function writeThemeOverrideConfig(themeDir) {
-  const tempFileHandle = await tmp.file({ postfix: ".yml" });
-
-  // The theme must be relative to the `theme` directory where it _would_ have
-  // lived, even if it won't be living there.  Therefore, we add `..` onto the
-  // front of whatever we already have (which is already relative).
-  await writeFile(tempFileHandle.fd, yaml.safeDump({
-    theme: "../" + themeDir,
-  }));
-
-  return tempFileHandle.path;
-}
-
 module.exports = {
   defaultConfigNpm,
   getConfigFromArguments,
   themeName,
-  writeThemeOverrideConfig
+
 };


### PR DESCRIPTION
I think I've been able to work around it, but we'll see once used by `meteor-theme-hexo` on its next test run!