### PR TITLE
Remove unused `tmp-promise` usage in `tools/utils.js`.

### DIFF
--- a/tools/utils.js
+++ b/tools/utils.js
@@ -4,7 +4,6 @@ const {
   join: pathJoin,
 } = require("path");
 
-const tmp = require("tmp-promise");
 const yaml = require("js-yaml");
 
 const defaultConfigNpm = "meteor-hexo-config";


### PR DESCRIPTION
This is an artifact that shouldn't be here.  I'm going to use `tmp-promise` in #27 though, so overall the package dependencies won't be changing.