### PR TITLE
Resolve configDirectory and themeDirectory to full paths before using.

### DIFF
--- a/tools/theme_instance.js
+++ b/tools/theme_instance.js
@@ -21,7 +21,11 @@ class ThemeInstance {
   constructor(options = {}) {
     console.log("Preparing to use:");
     console.log("  configPackage:", options.configPackage);
+    options.configDirectory =
+      options.configDirectory && pathResolve(options.configDirectory);
     console.log("  configDirectory:", options.configDirectory);
+    options.themeDirectory =
+      options.themeDirectory && pathResolve(options.themeDirectory);
     console.log("  themeDirectory:", options.themeDirectory);
     this.options = options;
   }


### PR DESCRIPTION
To allow us to more safely use the `--theme-dir`, which accepts relative paths, within other commands (for example, the `npm pack` within #27) which necessitate the full path.